### PR TITLE
manage cluster level blocked versions

### DIFF
--- a/cmd/ocm-aus/apply/policy/policy.go
+++ b/cmd/ocm-aus/apply/policy/policy.go
@@ -27,14 +27,15 @@ import (
 )
 
 var args struct {
-	organizationId string
-	clusterName    string
-	clusterUUID    string
-	schedule       string
-	workloads      []string
-	soakDays       int
-	sector         string
-	mutexes        []string
+	organizationId            string
+	clusterName               string
+	clusterUUID               string
+	schedule                  string
+	workloads                 []string
+	soakDays                  int
+	sector                    string
+	mutexes                   []string
+	blockedVersionExpressions []string
 
 	dryRun bool
 	dump   bool
@@ -104,6 +105,13 @@ func init() {
 		[]string{},
 		"The mutexes the cluster must hold before it can start an upgrade.",
 	)
+	flags.StringArrayVarP(
+		&args.blockedVersionExpressions,
+		"blocked-versions",
+		"b",
+		[]string{},
+		"Blocked version expressions.",
+	)
 	flags.BoolVar(
 		&args.dryRun,
 		"dry-run",
@@ -140,6 +148,7 @@ func run(cmd *cobra.Command, argv []string) error {
 				args.soakDays,
 				args.sector,
 				args.mutexes,
+				args.blockedVersionExpressions,
 			),
 		}
 	}

--- a/pkg/blockedversions/types.go
+++ b/pkg/blockedversions/types.go
@@ -19,6 +19,7 @@ package blockedversions
 import (
 	"encoding/json"
 	"io"
+	"regexp"
 	"sort"
 )
 
@@ -58,4 +59,16 @@ func ConsolidateVersionBlocks(currentVersionBlocks []string, toBlock []string, t
 	}
 
 	return result
+}
+
+func ParsedBlockedVersionExpressions(blockedVersions []string) ([]*regexp.Regexp, error) {
+	var blockedVersionExpressions []*regexp.Regexp
+	for _, blockedVersion := range blockedVersions {
+		blockedVersionExpression, err := regexp.Compile(blockedVersion)
+		if err != nil {
+			return nil, err
+		}
+		blockedVersionExpressions = append(blockedVersionExpressions, blockedVersionExpression)
+	}
+	return blockedVersionExpressions, nil
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -24,3 +24,12 @@ import (
 func StringArrayToCSV(array []string) string {
 	return strings.Trim(strings.Join(strings.Fields(fmt.Sprint(array)), ","), "[]")
 }
+
+func StringInArray(arr []string, str string) bool {
+	for _, s := range arr {
+		if s == str {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
support the `sre-capability.aus.blocked-version` subscription label that serves the same purpose as the organization label with the same name. both labels will be used together to block defined versions to be considered to upgrades.

to make sure that such labels can be safely added in the future, aus-cli will not touch unknown labels from now on.

part of https://issues.redhat.com/browse/APPSRE-7870