### PR TITLE
aus-cli dump commands don't require an OCM session for

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ Apply blocked versions to organization 2Q0awarcxlarxaWwrFFpbLITiGu
 
 Together with the `--replace` option, applying from a file makes sure that the desired state defined in the file is going to be the exact state on the organization.
 
+When `--dump` is used without the `--replace` option, one needs to be logged in to OCM.
+
 ## Manage sector dependencies
 
 Sectors are dependant groups of clusters. A version is only considered for upgrade within a sector if all dependant sectors have been fully upgraded to to that version.
@@ -172,6 +174,8 @@ Apply sector configuration to organization 2Q0awarcxlarxaWwrFFpbLITiGu
 
 Together with the `--replace` option, applying from a file makes sure that the desired state defined in the file is going to be the exact state on the organization.
 
+When `--dump` is used without the `--replace` option, one needs to be logged in to OCM.
+
 ## Manage cross-organization soak day inheritance
 
 Accumulated soak days can be inherited from other OCM organizations. This can be meaningful if a fleet of clusters is distributed accross various organizations or if organizations are used for different stages of continous delivery (integration, stage, prod). The involved organization can even exist in different OCM environment (integration, stage, prod).
@@ -217,6 +221,8 @@ Apply version data inheritance configuration to organization $target_org_id
 ```
 
 Together with the `--replace` option, applying from a file makes sure that the desired state defined in the file is going to be the exact state on the organization.
+
+When `--dump` is used without the `--replace` option, one needs to be logged in to OCM.
 
 ## Version gates
 

--- a/pkg/backend/ocmlabels/blockedversions.go
+++ b/pkg/backend/ocmlabels/blockedversions.go
@@ -45,18 +45,6 @@ func (f *OCMLabelsPolicyBackend) ListBlockedVersionExpressions(organizationId st
 }
 
 func (f *OCMLabelsPolicyBackend) ApplyBlockedVersionExpressions(organizationId string, blockExpressions []string, dumpVersionBlocks bool, dryRun bool) error {
-	connection, err := ocm.NewOCMConnection()
-	if err != nil {
-		return err
-	}
-
-	if organizationId == "" {
-		organizationId, err = ocm.CurrentOrganizationId(connection)
-		if err != nil {
-			return err
-		}
-	}
-
 	if dumpVersionBlocks {
 		body, err := json.Marshal(blockExpressions)
 		if err != nil {
@@ -67,6 +55,18 @@ func (f *OCMLabelsPolicyBackend) ApplyBlockedVersionExpressions(organizationId s
 			return err
 		}
 		return nil
+	}
+
+	connection, err := ocm.NewOCMConnection()
+	if err != nil {
+		return err
+	}
+
+	if organizationId == "" {
+		organizationId, err = ocm.CurrentOrganizationId(connection)
+		if err != nil {
+			return err
+		}
 	}
 
 	output.Log(dryRun, "Apply blocked version labels to organization %s\n", organizationId)

--- a/pkg/backend/ocmlabels/inheritance.go
+++ b/pkg/backend/ocmlabels/inheritance.go
@@ -47,18 +47,6 @@ func (f *OCMLabelsPolicyBackend) GetVersionDataInheritanceConfiguration(organiza
 }
 
 func (f *OCMLabelsPolicyBackend) ApplyVersionDataInheritanceConfiguration(organizationId string, inheritance versiondata.VersionDataInheritanceConfig, dumpConfig bool, dryRun bool) error {
-	connection, err := ocm.NewOCMConnection()
-	if err != nil {
-		return err
-	}
-
-	if organizationId == "" {
-		organizationId, err = ocm.CurrentOrganizationId(connection)
-		if err != nil {
-			return err
-		}
-	}
-
 	if dumpConfig {
 		body, err := json.Marshal(inheritance)
 		if err != nil {
@@ -69,6 +57,18 @@ func (f *OCMLabelsPolicyBackend) ApplyVersionDataInheritanceConfiguration(organi
 			return err
 		}
 		return nil
+	}
+
+	connection, err := ocm.NewOCMConnection()
+	if err != nil {
+		return err
+	}
+
+	if organizationId == "" {
+		organizationId, err = ocm.CurrentOrganizationId(connection)
+		if err != nil {
+			return err
+		}
 	}
 
 	output.Log(dryRun, "Apply version data inheritance configuration to organization %s\n", organizationId)

--- a/pkg/backend/ocmlabels/policy.go
+++ b/pkg/backend/ocmlabels/policy.go
@@ -86,17 +86,6 @@ func (f *OCMLabelsPolicyBackend) DeletePolicy(organizationId string, clusterName
 }
 
 func (f *OCMLabelsPolicyBackend) ApplyPolicies(organizationId string, policies []policy.ClusterUpgradePolicy, dumpPolicy bool, dryRun bool) error {
-	connection, err := ocm.NewOCMConnection()
-	if err != nil {
-		return err
-	}
-	if organizationId == "" {
-		organizationId, err = ocm.CurrentOrganizationId(connection)
-		if err != nil {
-			return err
-		}
-	}
-
 	if dumpPolicy {
 		body, err := json.Marshal(policies)
 		if err != nil {
@@ -107,6 +96,17 @@ func (f *OCMLabelsPolicyBackend) ApplyPolicies(organizationId string, policies [
 			return err
 		}
 		return nil
+	}
+
+	connection, err := ocm.NewOCMConnection()
+	if err != nil {
+		return err
+	}
+	if organizationId == "" {
+		organizationId, err = ocm.CurrentOrganizationId(connection)
+		if err != nil {
+			return err
+		}
 	}
 
 	for _, policy := range policies {

--- a/pkg/backend/ocmlabels/sector.go
+++ b/pkg/backend/ocmlabels/sector.go
@@ -46,18 +46,6 @@ func (f *OCMLabelsPolicyBackend) ListSectorConfiguration(organizationId string) 
 }
 
 func (f *OCMLabelsPolicyBackend) ApplySectorConfiguration(organizationId string, sectorDependencies []sectors.SectorDependencies, dumpSectorDeps bool, dryRun bool) error {
-	connection, err := ocm.NewOCMConnection()
-	if err != nil {
-		return err
-	}
-
-	if organizationId == "" {
-		organizationId, err = ocm.CurrentOrganizationId(connection)
-		if err != nil {
-			return err
-		}
-	}
-
 	if dumpSectorDeps {
 		body, err := json.Marshal(sectorDependencies)
 		if err != nil {
@@ -68,6 +56,18 @@ func (f *OCMLabelsPolicyBackend) ApplySectorConfiguration(organizationId string,
 			return err
 		}
 		return nil
+	}
+
+	connection, err := ocm.NewOCMConnection()
+	if err != nil {
+		return err
+	}
+
+	if organizationId == "" {
+		organizationId, err = ocm.CurrentOrganizationId(connection)
+		if err != nil {
+			return err
+		}
 	}
 
 	output.Log(dryRun, "Apply sector configuration to organization %s\n", organizationId)


### PR DESCRIPTION
this PR removes the need to be logged into OCM when using a commands `--dump` option. for commands that offer patch or replace functionality, an active OCM login is still required when used in patch mode. for a true gitops way of handling AUS configuration, `--replace` is the way to go anyways, so this should not be too restrictive.

```sh
ocm aus apply policies --dump -c my-cluster -s weekdays -w test -d 2
ocm aus apply version-blocks --dump --replace -b 4.15.0
ocm aus apply sectors --dump --replace -a a=b -a b=c -a a=c
ocm aus apply inheritance --dump --replace -i org1 -p org2
```

part of https://issues.redhat.com/browse/APPSRE-8707