### PR TITLE
handle all version gates

### DIFF
--- a/cmd/ocm-aus/get/gates/gates.go
+++ b/cmd/ocm-aus/get/gates/gates.go
@@ -114,7 +114,7 @@ func run(cmd *cobra.Command, argv []string) error {
 			if !cluster.STSEnabled() {
 				continue
 			}
-			missingAgreements, err := cluster.MissingSTSGateAgreements(blockedVersionExpressions, versionGates)
+			missingAgreements, err := cluster.MissingGateAgreements(blockedVersionExpressions, versionGates)
 			if err != nil {
 				return err
 			}

--- a/pkg/clusters/gates.go
+++ b/pkg/clusters/gates.go
@@ -28,7 +28,7 @@ func AckAllGatesForYStream(cluster *ClusterInfo, yStream string, connection *sdk
 	if err != nil {
 		return nil, err
 	}
-	unackedGates, err := cluster.MissingSTSGateAgreements(nil, gates)
+	unackedGates, err := cluster.MissingGateAgreements(nil, gates)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/clusters/upgrades.go
+++ b/pkg/clusters/upgrades.go
@@ -75,7 +75,7 @@ func (c *ClusterInfo) YStreamUpgrades(considerBlockedVersions bool, additionalBl
 	return keys
 }
 
-func (c *ClusterInfo) MissingSTSGateAgreements(additionalBlockedVersions []*regexp.Regexp, gates map[string][]*csv1.VersionGate) ([]*csv1.VersionGate, error) {
+func (c *ClusterInfo) MissingGateAgreements(additionalBlockedVersions []*regexp.Regexp, gates map[string][]*csv1.VersionGate) ([]*csv1.VersionGate, error) {
 	var missingGates []*csv1.VersionGate
 	for _, yStreamUpgrade := range c.YStreamUpgrades(true, additionalBlockedVersions) {
 		yStreamGates, ok := gates[yStreamUpgrade]
@@ -83,7 +83,7 @@ func (c *ClusterInfo) MissingSTSGateAgreements(additionalBlockedVersions []*rege
 			continue
 		}
 		for _, yStreamGate := range yStreamGates {
-			if !yStreamGate.STSOnly() || !c.STSEnabled() {
+			if yStreamGate.STSOnly() && !c.STSEnabled() {
 				continue
 			}
 
@@ -105,7 +105,7 @@ func (c *ClusterInfo) MissingSTSGateAgreements(additionalBlockedVersions []*rege
 }
 
 func (c *ClusterInfo) YStreamsWithMissingSTSGateAgreements(additionalBlockedVersions []*regexp.Regexp, gates map[string][]*csv1.VersionGate) ([]string, error) {
-	missingGates, err := c.MissingSTSGateAgreements(additionalBlockedVersions, gates)
+	missingGates, err := c.MissingGateAgreements(additionalBlockedVersions, gates)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
the `get gates` and `apply gate-agreement` commands will now act on the ingress gate and others as well.

part of https://issues.redhat.com/browse/APPSRE-10093