### PR TITLE
AUS CLI max parallel upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,25 +114,28 @@ Together with the `--replace` option, applying from a file makes sure that the d
 
 When `--dump` is used without the `--replace` option, one needs to be logged in to OCM.
 
-## Manage sector dependencies
+## Manage sector configurations
 
 Sectors are dependant groups of clusters. A version is only considered for upgrade within a sector if all dependant sectors have been fully upgraded to to that version.
 
-Create or replace an organizations sector dependencies with `ocm aus apply sectors [flags]`
+Create or replace an organizations sector configurations with `ocm aus apply sectors [flags]`
 
-| Flags        | Definition                                                                                                                               |
-|--------------|------------------------------------------------------------------------------------------------------------------------------------------|
-| --add-dep    | `A=B,C` ... Establishes a dependency from sector A to sectors B and C. Can be specified multiple times.                                  |
-| --remove-dep | `A=B`   ... Deletes the dependency from sector A to sector B.                                                                            |
-| --replace    | Replaces all existing sector dependencies with the ones specified by `--add-sector-dep` or the ones provided via stdin.                  |
-| --org-id     | The OCM organization ID where the sectors and dependencies are defined. Defaults to the organization ID of the currently logged in user. |
+| Flags                          | Definition                                                                                                                                            |
+|--------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
+| --sector-max-parallel-upgrades | `A=x` or `A=x%` ... Sets the maximum number (or percent) `x` of concurrent upgrades within sector A. Can be specified for each sector.                |
+| --add-dep                      | `A=B,C` ... Establishes a dependency from sector A to sectors B and C. Can be specified multiple times.                                               |
+| --remove-dep                   | `A=B`   ... Deletes the dependency from sector A to sector B.                                                                                         |
+| --replace                      | Replaces all existing sector config with the ones specified by `--add-dep` and `--sector-max-parallel-upgrades` or the ones provided via stdin.       |
+| --org-id                       | The OCM organization ID where the sectors are defined. Defaults to the organization ID of the currently logged in user.                               |
 
 ```shell
-ocm aus apply sectors --add-dep prod=stage --add-dep stage=dev,dev-2
-ocm aus apply sectors --remove-dep stage=dev-2
-Apply sector configuration to organization 2Q0awarcxlarxaWwrFFpbLITiGu
+# apply a config at once
+$ ocm aus apply sectors --add-dep prod=stage --add-dep stage=dev,dev-2 --sector-max-parallel-upgrades stage=10 --sector-max-parallel-upgrades prod=20%
 
-ocm aus get sectors
+# remove a single sector dependency from `stage` and reset the max-parallel-upgrade setting for `stage`
+$ ocm aus apply sectors --remove-dep stage=dev-2 --sector-max-parallel-upgrades stage=
+
+$ ocm aus get sectors
 [
   {
     "dependencies": [
@@ -144,12 +147,13 @@ ocm aus get sectors
     "dependencies": [
        "stage"
     ],
+    "maxParallelUpgrades": "20%",
     "name": "prod"
   }
 ]
 ```
 
-Sector dependencies can also be written to a file and applied from a file.
+Sector configs can also be written to a file and applied from a file.
 
 ```shell
 ocm aus apply sectors --add-dep prod=stage --add-dep stage=dev --replace --dump | tee sector-deps.json

--- a/cmd/ocm-aus/apply/sector/sector.go
+++ b/cmd/ocm-aus/apply/sector/sector.go
@@ -91,7 +91,7 @@ func init() {
 }
 
 func run(cmd *cobra.Command, argv []string) error {
-	var sectorDependencies []sectors.SectorDependencies
+	var sectorDependencies []sectors.Sector
 	var err error
 
 	backendType, err := cmd.Flags().GetString("backend")
@@ -103,7 +103,7 @@ func run(cmd *cobra.Command, argv []string) error {
 		return err
 	}
 
-	var adding, removing []sectors.SectorDependencies
+	var adding, removing []sectors.Sector
 	if len(argv) > 0 && argv[0] == "-" {
 		adding, err = sectors.ReadSectorDependenciesFromReader(cmd.InOrStdin())
 		if err != nil {
@@ -122,7 +122,7 @@ func run(cmd *cobra.Command, argv []string) error {
 	}
 
 	// consolidate dependencies
-	var currentSectorDependencies []sectors.SectorDependencies = []sectors.SectorDependencies{}
+	var currentSectorDependencies []sectors.Sector = []sectors.Sector{}
 	if !args.replace {
 		currentSectorDependencies, err = be.ListSectorConfiguration(args.organizationId)
 		if err != nil {

--- a/cmd/ocm-aus/apply/sector/sector.go
+++ b/cmd/ocm-aus/apply/sector/sector.go
@@ -25,12 +25,13 @@ import (
 )
 
 var args struct {
-	organizationId string
-	add            []string
-	remove         []string
-	replace        bool
-	dryRun         bool
-	dump           bool
+	organizationId            string
+	sectorMaxParallelUpgrades []string
+	add                       []string
+	remove                    []string
+	replace                   bool
+	dryRun                    bool
+	dump                      bool
 }
 
 var Cmd = &cobra.Command{
@@ -55,6 +56,13 @@ func init() {
 		"The ID of the OCM organization to manage",
 	)
 
+	flags.StringArrayVarP(
+		&args.sectorMaxParallelUpgrades,
+		"sector-max-parallel-upgrades",
+		"m",
+		[]string{},
+		"",
+	)
 	flags.StringArrayVarP(
 		&args.add,
 		"add-dep",
@@ -91,7 +99,7 @@ func init() {
 }
 
 func run(cmd *cobra.Command, argv []string) error {
-	var sectorDependencies []sectors.Sector
+	var sectorList []sectors.Sector
 	var err error
 
 	backendType, err := cmd.Flags().GetString("backend")
@@ -103,13 +111,18 @@ func run(cmd *cobra.Command, argv []string) error {
 		return err
 	}
 
-	var adding, removing []sectors.Sector
+	var sectorsMaxParallelUpgrades, adding, removing []sectors.Sector
 	if len(argv) > 0 && argv[0] == "-" {
-		adding, err = sectors.ReadSectorDependenciesFromReader(cmd.InOrStdin())
+		adding, err = sectors.ReadSectorsFromReader(cmd.InOrStdin())
 		if err != nil {
 			return fmt.Errorf("failed to decode input: %v", err)
 		}
 	} else {
+		sectorsMaxParallelUpgrades, err = sectors.NewSectorMaxParallelUpgradesList(args.sectorMaxParallelUpgrades)
+		if err != nil {
+			return err
+		}
+
 		adding, err = sectors.NewSectorDependenciesList(args.add)
 		if err != nil {
 			return err
@@ -122,18 +135,18 @@ func run(cmd *cobra.Command, argv []string) error {
 	}
 
 	// consolidate dependencies
-	var currentSectorDependencies []sectors.Sector = []sectors.Sector{}
+	var currentSectors []sectors.Sector = []sectors.Sector{}
 	if !args.replace {
-		currentSectorDependencies, err = be.ListSectorConfiguration(args.organizationId)
+		currentSectors, err = be.ListSectorConfiguration(args.organizationId)
 		if err != nil {
 			return err
 		}
 	}
-	sectorDependencies = sectors.ConsolidateSectorDependencies(
-		currentSectorDependencies, adding, removing,
+	sectorList = sectors.ConsolidateSectorList(
+		currentSectors, adding, removing, sectorsMaxParallelUpgrades,
 	)
 
-	err = be.ApplySectorConfiguration(args.organizationId, sectorDependencies, args.dump, args.dryRun)
+	err = be.ApplySectorConfiguration(args.organizationId, sectorList, args.dump, args.dryRun)
 	if err != nil {
 		return err
 	}

--- a/cmd/ocm-aus/status/cmd.go
+++ b/cmd/ocm-aus/status/cmd.go
@@ -100,10 +100,10 @@ func run(cmd *cobra.Command, argv []string) error {
 
 		w.WriteString("Sector Configuration:\t(%d in total)\n", len(sectors))
 		if len(sectors) > 0 {
-			w1.WriteString("Name\tDepends on\n")
-			w1.WriteString("----\t----------\n")
+			w1.WriteString("Name\tMax Parallel Upgrades\tDepends on\n")
+			w1.WriteString("----\t---------------------\t----------\n")
 			for _, sector := range sectors {
-				w1.WriteString("%s\t%s\n", sector.Name, strings.Join(sector.Dependencies, ", "))
+				w1.WriteString("%s\t%s\t%s\n", sector.Name, sector.MaxParallelUpgrades, strings.Join(sector.Dependencies, ", "))
 			}
 		}
 

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -40,7 +40,7 @@ type PolicyBackend interface {
 
 	ListSectorConfiguration(organizationId string) ([]sectors.Sector, error)
 
-	ApplySectorConfiguration(organizationId string, sectorDependencies []sectors.Sector, dumpSectorDeps bool, dryRun bool) error
+	ApplySectorConfiguration(organizationId string, sectors []sectors.Sector, dumpSectors bool, dryRun bool) error
 
 	GetVersionDataInheritanceConfiguration(organizationId string) (versiondata.VersionDataInheritanceConfig, error)
 

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -38,15 +38,15 @@ type PolicyBackend interface {
 
 	ApplyBlockedVersionExpressions(organizationId string, blockExpressions []string, dumpVersionBlocks bool, dryRun bool) error
 
-	ListSectorConfiguration(organizationId string) ([]sectors.SectorDependencies, error)
+	ListSectorConfiguration(organizationId string) ([]sectors.Sector, error)
 
-	ApplySectorConfiguration(organizationId string, sectorDependencies []sectors.SectorDependencies, dumpSectorDeps bool, dryRun bool) error
+	ApplySectorConfiguration(organizationId string, sectorDependencies []sectors.Sector, dumpSectorDeps bool, dryRun bool) error
 
 	GetVersionDataInheritanceConfiguration(organizationId string) (versiondata.VersionDataInheritanceConfig, error)
 
 	ApplyVersionDataInheritanceConfiguration(organizationId string, inheritance versiondata.VersionDataInheritanceConfig, dumpConfig bool, dryRun bool) error
 
-	Status(organizationId string, showClustersWithoutPolicy bool) (organization *amv1.Organization, clusterInfos []*clusters.ClusterInfo, blockedVersions []string, sectors []sectors.SectorDependencies, inheritance versiondata.VersionDataInheritanceConfig, err error)
+	Status(organizationId string, showClustersWithoutPolicy bool) (organization *amv1.Organization, clusterInfos []*clusters.ClusterInfo, blockedVersions []string, sectors []sectors.Sector, inheritance versiondata.VersionDataInheritanceConfig, err error)
 }
 
 func NewPolicyBackend(backendType string) (PolicyBackend, error) {

--- a/pkg/backend/ocmlabels/sector.go
+++ b/pkg/backend/ocmlabels/sector.go
@@ -30,7 +30,7 @@ import (
 	amv1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
 )
 
-func (f *OCMLabelsPolicyBackend) ListSectorConfiguration(organizationId string) ([]sectors.SectorDependencies, error) {
+func (f *OCMLabelsPolicyBackend) ListSectorConfiguration(organizationId string) ([]sectors.Sector, error) {
 	connection, err := ocm.NewOCMConnection()
 	if err != nil {
 		return nil, err
@@ -45,7 +45,7 @@ func (f *OCMLabelsPolicyBackend) ListSectorConfiguration(organizationId string) 
 	return listSectorConfigurationFromOrganizationLabels(organizationId, connection)
 }
 
-func (f *OCMLabelsPolicyBackend) ApplySectorConfiguration(organizationId string, sectorDependencies []sectors.SectorDependencies, dumpSectorDeps bool, dryRun bool) error {
+func (f *OCMLabelsPolicyBackend) ApplySectorConfiguration(organizationId string, sectorDependencies []sectors.Sector, dumpSectorDeps bool, dryRun bool) error {
 	if dumpSectorDeps {
 		body, err := json.Marshal(sectorDependencies)
 		if err != nil {
@@ -93,20 +93,20 @@ func listOrganizationSectorLabels(organizationId string, connection *sdk.Connect
 	return listOrganizationLabels(organizationId, newAusLabelKey("sector-deps."), connection)
 }
 
-func listSectorConfigurationFromOrganizationLabels(organizationId string, connection *sdk.Connection) ([]sectors.SectorDependencies, error) {
+func listSectorConfigurationFromOrganizationLabels(organizationId string, connection *sdk.Connection) ([]sectors.Sector, error) {
 	labels, err := listOrganizationLabels(organizationId, newAusLabelKey("sector-deps."), connection)
 	if err != nil {
 		return nil, err
 	}
-	sectorDeps := []sectors.SectorDependencies{}
+	sectorDeps := []sectors.Sector{}
 	for _, sectorLabel := range labels {
 		sectorName := strings.TrimPrefix(sectorLabel.Key(), newAusLabelKey("sector-deps."))
-		sectorDeps = append(sectorDeps, sectors.SectorDependencies{Name: sectorName, Dependencies: strings.Split(sectorLabel.Value(), ",")})
+		sectorDeps = append(sectorDeps, sectors.Sector{Name: sectorName, Dependencies: strings.Split(sectorLabel.Value(), ",")})
 	}
 	return sectorDeps, nil
 }
 
-func sectorDependencyToLabels(sectorDep sectors.SectorDependencies, organizationId string) (*amv1.Label, error) {
+func sectorDependencyToLabels(sectorDep sectors.Sector, organizationId string) (*amv1.Label, error) {
 	return buildOCMLabel(
 		newAusLabelKey(fmt.Sprintf("sector-deps.%s", sectorDep.Name)), utils.StringArrayToCSV(sectorDep.Dependencies), "", organizationId,
 	)

--- a/pkg/backend/ocmlabels/status.go
+++ b/pkg/backend/ocmlabels/status.go
@@ -48,7 +48,7 @@ func (f *OCMLabelsPolicyBackend) Status(organizationId string, showClustersWitho
 	}
 	clusters.SortClusters(clusterInfos)
 
-	sectors, err = listSectorConfigurationFromOrganizationLabels(organization.ID(), connection)
+	sectors, err = listSectorsFromOrganizationLabels(organization.ID(), connection)
 	if err != nil {
 		return
 	}

--- a/pkg/backend/ocmlabels/status.go
+++ b/pkg/backend/ocmlabels/status.go
@@ -24,7 +24,7 @@ import (
 	amv1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
 )
 
-func (f *OCMLabelsPolicyBackend) Status(organizationId string, showClustersWithoutPolicy bool) (organization *amv1.Organization, clusterInfos []*clusters.ClusterInfo, blockedVersions []string, sectors []sectors.SectorDependencies, inheritance versiondata.VersionDataInheritanceConfig, err error) {
+func (f *OCMLabelsPolicyBackend) Status(organizationId string, showClustersWithoutPolicy bool) (organization *amv1.Organization, clusterInfos []*clusters.ClusterInfo, blockedVersions []string, sectors []sectors.Sector, inheritance versiondata.VersionDataInheritanceConfig, err error) {
 	connection, err := ocm.NewOCMConnection()
 	if err != nil {
 		return


### PR DESCRIPTION
https://issues.redhat.com/browse/APPSRE-11690

This adds `MaxParallelUpgrades` support in `aus-cli`.

This setting allow to limit the number of concurrent upgrades within a sector.

* `aus status` was updated
* `aus get sectors` was working out of the boc since it dumps the JSON
* `aus apply sectors` was amended with an option `--sector-max-parallel-upgrades` to be able to set (and remove) the value for a given sector